### PR TITLE
first go adding CircleCI integration

### DIFF
--- a/.circleci/config.yaml
+++ b/.circleci/config.yaml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build-and-test:
+    docker:
+      - image: circleci/golang:1.11
+
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    environment:
+      GO111MODULE: on
+    steps:
+      - checkout
+      - run: go test -v ./...


### PR DESCRIPTION
Adds simple circleCI config that builds gdt in docker and runs the tests