### PR TITLE
Add `gdt.Debugf` utility function

### DIFF
--- a/examples/books/api/suite_test.go
+++ b/examples/books/api/suite_test.go
@@ -39,7 +39,7 @@ var _ = AfterSuite(func() {
 	server.Close()
 })
 
-func TestBooksAPI(t *testing.T) {
+func TestBooksAPI_Ginkgo(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Books API Suite")
 }

--- a/examples/books/tests/api/suite_test.go
+++ b/examples/books/tests/api/suite_test.go
@@ -24,7 +24,7 @@ var (
 	}
 )
 
-func TestBooksAPI(t *testing.T) {
+func TestBooksAPI_HTTP(t *testing.T) {
 	// Register an HTTP server fixture that spins up the API service on a
 	// random port on localhost
 	dataFilepath := "testdata/fixtures.json"
@@ -36,7 +36,7 @@ func TestBooksAPI(t *testing.T) {
 	if err = json.NewDecoder(dataFile).Decode(&data); err != nil {
 		panic(err)
 	}
-	logger := log.New(os.Stdout, "http: ", log.LstdFlags)
+	logger := log.New(os.Stdout, "books_api_http: ", log.LstdFlags)
 	c := api.NewControllerWithBooks(logger, data.Books)
 	apiFixture := http.NewHTTPServerFixture(c.Router())
 	gdt.Fixtures.Register("books_api", apiFixture)

--- a/file.go
+++ b/file.go
@@ -41,6 +41,7 @@ func (f *file) Run(t *testing.T) {
 			if fix == nil {
 				t.Fatalf("failed to find required fixture '%s'", fname)
 			}
+			Debugf("[gdt.file.file:Run] starting fixture %s\n", fname)
 			fix.Start()
 			defer fix.Stop()
 		}

--- a/http/file.go
+++ b/http/file.go
@@ -171,7 +171,9 @@ func (ht *httpTest) processRequestData() {
 	if ht.data == nil {
 		return
 	}
-
+	gdt.Debugf("[gdt.http.file.httpTest:processRequestData]\n")
+	gdt.Debugf("  %+v\n", ht.data)
+	gdt.Debugf("[/gdt.http.file.httpTest:processRequestData]\n")
 	// Get a pointer to the unmarshaled interface{} so we can mutate the
 	// contents pointed to
 	p := reflect.ValueOf(&ht.data)
@@ -204,6 +206,7 @@ func (ht *httpTest) Run(t *testing.T) {
 		require.Nil(t, err)
 		body = bytes.NewReader(jsonBody)
 	}
+	gdt.Debugf("[gdt.http.file.httpTest:Run] running test %s\n", ht.name)
 	t.Run(ht.name, func(t *testing.T) {
 		url, err := ht.getURL()
 		require.Nil(t, err)

--- a/http/file.go
+++ b/http/file.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	nethttp "net/http"
 	"reflect"
 	"strings"
@@ -208,7 +207,7 @@ func (ht *httpTest) Run(t *testing.T) {
 	t.Run(ht.name, func(t *testing.T) {
 		url, err := ht.getURL()
 		require.Nil(t, err)
-		req, err := http.NewRequest(ht.method, url, body)
+		req, err := nethttp.NewRequest(ht.method, url, body)
 		require.Nil(t, err)
 		// TODO(jaypipes): Allow customization of the HTTP client for proxying,
 		// TLS, etc

--- a/print.go
+++ b/print.go
@@ -1,0 +1,21 @@
+package gdt
+
+import (
+	"flag"
+	"fmt"
+)
+
+var optDebug bool
+
+func init() {
+	flag.BoolVar(&optDebug, "gdt.debug", false, "Turn on the gdt library's debug output.")
+}
+
+// Debugf prints the supplied message with args if the gdt.debug flag has been
+// set to a truthy value
+func Debugf(msg string, args ...interface{}) {
+	if !optDebug {
+		return
+	}
+	fmt.Printf(msg, args...)
+}


### PR DESCRIPTION
Adds a simple debug print utility function to gdt and cleans up some exported symbols in the example application that should have been private.