### PR TITLE
Allow HTTP Server fixtures with TLS

### DIFF
--- a/examples/books/tests/api/suite_test.go
+++ b/examples/books/tests/api/suite_test.go
@@ -38,7 +38,42 @@ func TestBooksAPI_HTTP(t *testing.T) {
 	}
 	logger := log.New(os.Stdout, "books_api_http: ", log.LstdFlags)
 	c := api.NewControllerWithBooks(logger, data.Books)
-	apiFixture := http.NewHTTPServerFixture(c.Router())
+	apiFixture := http.NewServerFixture(c.Router(), false /* useTLS */)
+	gdt.Fixtures.Register("books_api", apiFixture)
+
+	dataFile.Seek(0, io.SeekStart)
+	dataFixture, err := fixtures.NewJSONFixture(dataFile)
+	if err != nil {
+		panic(err)
+	}
+	gdt.Fixtures.Register("books_data", dataFixture)
+
+	// Construct a new gdt.Runnable from the directory of this file
+	_, filename, _, _ := runtime.Caller(0)
+	cwd := filepath.Dir(filename)
+
+	ts, err := gdt.From(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts.Run(t)
+}
+
+func TestBooksAPI_HTTPS(t *testing.T) {
+	// Register an HTTPS server fixture that spins up the API service on a
+	// random port on localhost and a well-known cert for localhost/127.0.0.1
+	dataFilepath := "testdata/fixtures.json"
+
+	dataFile, err := os.Open(dataFilepath)
+	if err != nil {
+		panic(err)
+	}
+	if err = json.NewDecoder(dataFile).Decode(&data); err != nil {
+		panic(err)
+	}
+	logger := log.New(os.Stdout, "books_api_http: ", log.LstdFlags)
+	c := api.NewControllerWithBooks(logger, data.Books)
+	apiFixture := http.NewServerFixture(c.Router(), true /* useTLS */)
 	gdt.Fixtures.Register("books_api", apiFixture)
 
 	dataFile.Seek(0, io.SeekStart)

--- a/file.go
+++ b/file.go
@@ -41,7 +41,7 @@ func (f *file) Run(t *testing.T) {
 			if fix == nil {
 				t.Fatalf("failed to find required fixture '%s'", fname)
 			}
-			Debugf("[gdt.file.file:Run] starting fixture %s\n", fname)
+			V2("file.file:Run", "starting fixture %s\n", fname)
 			fix.Start()
 			defer fix.Stop()
 		}

--- a/http/file.go
+++ b/http/file.go
@@ -216,13 +216,23 @@ func (ht *httpTest) Run(t *testing.T) {
 		url, err := ht.getURL()
 		require.Nil(t, err)
 		req, err := nethttp.NewRequest(ht.method, url, body)
-		gdt.V2("http.file.httpTest:Run", "constructed http.Request: %+v\n", req)
 		require.Nil(t, err)
+		gdt.V2("http.file.httpTest:Run", "constructed http.Request: %+v\n", req)
+
 		// TODO(jaypipes): Allow customization of the HTTP client for proxying,
 		// TLS, etc
 		c := ht.f.client()
+
 		resp, err := c.Do(req)
+		gdt.V2("http.file.httpTest:Run", "got http.Response: %+v\n", resp)
 		require.Nil(t, err)
+
+		// Make sure we drain and close our response body...
+		defer func() {
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+		}()
+
 		if ht.responseAssertion != nil {
 			// Only read the response body contents once and pass the byte
 			// buffer to the assertion functions

--- a/http/fixture.go
+++ b/http/fixture.go
@@ -27,7 +27,9 @@ func (f *httpServerFixture) Stop() {
 }
 
 func (f *httpServerFixture) HasState(key string) bool {
-	if strings.ToLower(key) == FIXTURE_STATE_KEY_BASE_URL {
+	lkey := strings.ToLower(key)
+	switch lkey {
+	case FIXTURE_STATE_KEY_BASE_URL, FIXTURE_STATE_KEY_CLIENT:
 		return true
 	}
 	return false

--- a/http/fixture.go
+++ b/http/fixture.go
@@ -16,10 +16,15 @@ const (
 type httpServerFixture struct {
 	handler nethttp.Handler
 	server  *httptest.Server
+	useTLS  bool
 }
 
 func (f *httpServerFixture) Start() {
-	f.server = httptest.NewServer(f.handler)
+	if !f.useTLS {
+		f.server = httptest.NewServer(f.handler)
+	} else {
+		f.server = httptest.NewTLSServer(f.handler)
+	}
 }
 
 func (f *httpServerFixture) Stop() {
@@ -46,10 +51,10 @@ func (f *httpServerFixture) State(key string) interface{} {
 	return ""
 }
 
-// NewHTTPServerFixture returns a fixture that will start and stop a supplied
+// NewServerFixture returns a fixture that will start and stop a supplied
 // http.Handler. The returned fixture exposes an "http.base_url" state key that
 // test cases of type "http" examine to determine the base URL the tests should
 // hit
-func NewHTTPServerFixture(h nethttp.Handler) gdt.Fixture {
-	return &httpServerFixture{handler: h}
+func NewServerFixture(h nethttp.Handler, useTLS bool) gdt.Fixture {
+	return &httpServerFixture{handler: h, useTLS: useTLS}
 }

--- a/print.go
+++ b/print.go
@@ -5,17 +5,28 @@ import (
 	"fmt"
 )
 
-var optDebug bool
+var optVerbosity int
 
 func init() {
-	flag.BoolVar(&optDebug, "gdt.debug", false, "Turn on the gdt library's debug output.")
+	flag.IntVar(&optVerbosity, "gdt.v", 0, "Increase verbosity of gdt library's debugging output.")
 }
 
-// Debugf prints the supplied message with args if the gdt.debug flag has been
-// set to a truthy value
-func Debugf(msg string, args ...interface{}) {
-	if !optDebug {
+// V1 prints the supplied message with args if the gdt.verbosity flag has been
+// set to 1 or more.
+func V1(callID string, msg string, args ...interface{}) {
+	debugf(1, callID, msg, args...)
+}
+
+// V2 prints the supplied message with args if the gdt.verbosity flag has been
+// set to 2 or more.
+func V2(callID string, msg string, args ...interface{}) {
+	debugf(2, callID, msg, args...)
+}
+
+func debugf(v int, callID string, msg string, args ...interface{}) {
+	if optVerbosity < v {
 		return
 	}
-	fmt.Printf(msg, args...)
+	line := fmt.Sprintf("[gdt.%s] %s", callID, msg)
+	fmt.Printf(line, args...)
 }

--- a/print.go
+++ b/print.go
@@ -23,6 +23,12 @@ func V2(callID string, msg string, args ...interface{}) {
 	debugf(2, callID, msg, args...)
 }
 
+// V3 prints the supplied message with args if the gdt.verbosity flag has been
+// set to 3 or more.
+func V3(callID string, msg string, args ...interface{}) {
+	debugf(3, callID, msg, args...)
+}
+
 func debugf(v int, callID string, msg string, args ...interface{}) {
 	if optVerbosity < v {
 		return


### PR DESCRIPTION
Renames the gdt.http.NewHTTPServerFixture to gdt.http.NewServerFixture
and adds a useTLS bool arg.

Closes Issue #7