### PR TITLE
support all JSONSchema format string validators

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -291,8 +291,31 @@ the expected format of that value.
 
 #### Valid format strings
 
-The currently supported format strings are:
+The currently supported format strings are all format strings in Draft7 of
+JSONSchema plus the "uuid4" variant:
 
+* "date": must be a date string in the format YYYY-MM-DD
+* "time": must be a time string in format HH:MM:SSZ-07:00 or HH:MM:SS
+* "date-time": must be a date-time string in any of the following formats:
+
+ * YYYY-MM-DDTHH:MM:SSZ-0700
+ * YYYY-MM-DD
+ * HH:MM:SSZ-0700
+ * HH:MM:SS
+
+* "hostname": must be a valid DNS hostname (RFC 952 and RFC 1123)
+* "email": must be a valid email address (RFC 5322)
+* "idn-email": must be a valid email address (RFC 5322)
+* "ipv4": must be a valid IPv4 address (RFC 791)
+* "ipv6": must be a valid IPv6 address (RFC 4291)
+* "uri": must be a valid URI (RFC 3986)
+* "uri-reference": must be a valid URI or relative-reference (RFC 3986)
+* "iri": must be a valid URI (RFC 3986)
+* "iri-reference": must be a valid URI or relative-reference (RFC 3986)
+* "uri-template": must be a valid URI template (RFC 6570)
+* "regex": must be a valid POSIX regular expression
+* "json-pointer": must be a valid JSON pointer value
+* "relative-json-pointer": must be a valid relative JSON pointer value
 * "uuid": must be any version of UUID
 * "uuid4": must be a UUID version 4
 

--- a/http/assertions.go
+++ b/http/assertions.go
@@ -116,7 +116,7 @@ func assertJSONPathFormat(t *testing.T, r *nethttp.Response, path string, format
 	require.Nil(t, err, msgJSONPathError, path, err)
 	gotStr, ok := got.(string)
 	assert.True(t, ok, msgJSONPathStringValue, path, got)
-	ok, err = isFormatted(format, gotStr)
+	ok, err = isFormatted(format, got)
 	require.Nil(t, err, msgFormatInvalid, format)
 	assert.True(t, ok, msgFormatBad, format, gotStr)
 }

--- a/http/formats.go
+++ b/http/formats.go
@@ -4,34 +4,50 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	gjs "github.com/xeipuuv/gojsonschema"
 )
 
-type validator func(string) bool
-
 var (
-	validators = map[string]validator{
-		"uuid":  isUUID,
-		"uuid4": isUUID4,
+	validators = map[string]gjs.FormatChecker{
+		"date":                  gjs.DateFormatChecker{},
+		"time":                  gjs.TimeFormatChecker{},
+		"date-time":             gjs.DateTimeFormatChecker{},
+		"hostname":              gjs.HostnameFormatChecker{},
+		"email":                 gjs.EmailFormatChecker{},
+		"idn-email":             gjs.EmailFormatChecker{},
+		"ipv4":                  gjs.IPV4FormatChecker{},
+		"ipv6":                  gjs.IPV6FormatChecker{},
+		"uri":                   gjs.URIFormatChecker{},
+		"uri-reference":         gjs.URIReferenceFormatChecker{},
+		"iri":                   gjs.URIFormatChecker{},
+		"iri-reference":         gjs.URIReferenceFormatChecker{},
+		"uri-template":          gjs.URITemplateFormatChecker{},
+		"uuid":                  gjs.UUIDFormatChecker{},
+		"regex":                 gjs.RegexFormatChecker{},
+		"json-pointer":          gjs.JSONPointerFormatChecker{},
+		"relative-json-pointer": gjs.RelativeJSONPointerFormatChecker{},
+		"uuid4":                 uuid4FormatChecker{},
 	}
 )
 
 // isFormatted takes a format string and a string value, determines the
 // validator function for that type of format string and returns whether the
 // value string is formatted correctly.
-func isFormatted(format string, value string) (bool, error) {
-	fn, ok := validators[format]
+func isFormatted(format string, input interface{}) (bool, error) {
+	c, ok := validators[format]
 	if !ok {
 		return false, fmt.Errorf("unknown format %s", format)
 	}
-	return fn(value), nil
+	return c.IsFormat(input), nil
 }
 
-func isUUID(s string) bool {
-	_, err := uuid.Parse(s)
-	return err == nil
-}
+type uuid4FormatChecker struct{}
 
-func isUUID4(s string) bool {
+func (c uuid4FormatChecker) IsFormat(input interface{}) bool {
+	s, ok := input.(string)
+	if !ok {
+		return false
+	}
 	u, err := uuid.Parse(s)
 	if err != nil {
 		return false


### PR DESCRIPTION
Adds support for all JSONSchema format strings in the path_formats
element.

Closes Issue #2