### PR TITLE
add Makefile and start cleaning up unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+VERSION ?= $(shell git describe --tags --always --dirty)
+
+.PHONY: test test-unit test-example
+
+test-unit:
+	GO111MODULE=on go test -v ./
+	GO111MODULE=on go test -v ./http
+
+test-example:
+	GO111MODULE=on go test -v ./examples/books/api
+	GO111MODULE=on go test -v ./examples/books/tests/api
+
+test: test-unit test-example

--- a/parse_test.go
+++ b/parse_test.go
@@ -12,7 +12,7 @@ func (p *fooParser) Parse(ContextAppendable, []byte) error {
 	return nil
 }
 
-func TestParseContents(t *testing.T) {
+func TestParseBytes(t *testing.T) {
 	fakeParsers := map[string]Parser{
 		"foo": &fooParser{},
 	}
@@ -53,7 +53,7 @@ name: foo test
 		tf := file{
 			name: test.name,
 		}
-		got := parseContents(&tf, test.contents, &fakeParsers)
+		got := parseBytes(&tf, test.contents, &fakeParsers)
 		assert.Equal(t, test.exp, got)
 	}
 }


### PR DESCRIPTION
Adds a simple Makefile and converts the exported `gdt.Parse` function into an unexported
`gdt.file:File.parse` method that accepts an io.Reader instead of a
filepath string. This means we can reduce duplicative os.Open calls
since the `gdt.From` function already os.Open'd the test file to
determine if it's a directory or not.