### PR TITLE
standardize registry types and clean up fixtures

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package gdt
 
 import "errors"

--- a/examples/books/tests/api/suite_test.go
+++ b/examples/books/tests/api/suite_test.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package api_test
 
 import (
@@ -16,43 +20,57 @@ import (
 	"github.com/jaypipes/gdt/examples/books/api"
 )
 
-var (
-	data struct {
-		Authors    interface{}
-		Publishers interface{}
-		Books      []*api.Book
-	}
+const (
+	dataFilePath = "testdata/fixtures.json"
 )
+
+type dataset struct {
+	Authors    interface{}
+	Publishers interface{}
+	Books      []*api.Book
+}
+
+func data() *dataset {
+	f, err := os.Open(dataFilePath)
+	if err != nil {
+		panic(err)
+	}
+	data := &dataset{}
+	if err = json.NewDecoder(f).Decode(&data); err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func currentDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Dir(filename)
+}
+
+func dataFixture() gdt.Fixture {
+	f, err := os.Open(dataFilePath)
+	if err != nil {
+		panic(err)
+	}
+	f.Seek(0, io.SeekStart)
+	fix, err := fixtures.NewJSONFixture(f)
+	if err != nil {
+		panic(err)
+	}
+	return fix
+}
 
 func TestBooksAPI_HTTP(t *testing.T) {
 	// Register an HTTP server fixture that spins up the API service on a
 	// random port on localhost
-	dataFilepath := "testdata/fixtures.json"
-
-	dataFile, err := os.Open(dataFilepath)
-	if err != nil {
-		panic(err)
-	}
-	if err = json.NewDecoder(dataFile).Decode(&data); err != nil {
-		panic(err)
-	}
 	logger := log.New(os.Stdout, "books_api_http: ", log.LstdFlags)
-	c := api.NewControllerWithBooks(logger, data.Books)
+	c := api.NewControllerWithBooks(logger, data().Books)
 	apiFixture := http.NewServerFixture(c.Router(), false /* useTLS */)
 	gdt.Fixtures.Register("books_api", apiFixture)
-
-	dataFile.Seek(0, io.SeekStart)
-	dataFixture, err := fixtures.NewJSONFixture(dataFile)
-	if err != nil {
-		panic(err)
-	}
-	gdt.Fixtures.Register("books_data", dataFixture)
+	gdt.Fixtures.Register("books_data", dataFixture())
 
 	// Construct a new gdt.Runnable from the directory of this file
-	_, filename, _, _ := runtime.Caller(0)
-	cwd := filepath.Dir(filename)
-
-	ts, err := gdt.From(cwd)
+	ts, err := gdt.From(currentDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,32 +80,14 @@ func TestBooksAPI_HTTP(t *testing.T) {
 func TestBooksAPI_HTTPS(t *testing.T) {
 	// Register an HTTPS server fixture that spins up the API service on a
 	// random port on localhost and a well-known cert for localhost/127.0.0.1
-	dataFilepath := "testdata/fixtures.json"
-
-	dataFile, err := os.Open(dataFilepath)
-	if err != nil {
-		panic(err)
-	}
-	if err = json.NewDecoder(dataFile).Decode(&data); err != nil {
-		panic(err)
-	}
 	logger := log.New(os.Stdout, "books_api_https: ", log.LstdFlags)
-	c := api.NewControllerWithBooks(logger, data.Books)
+	c := api.NewControllerWithBooks(logger, data().Books)
 	apiFixture := http.NewServerFixture(c.Router(), true /* useTLS */)
 	gdt.Fixtures.Register("books_api", apiFixture)
-
-	dataFile.Seek(0, io.SeekStart)
-	dataFixture, err := fixtures.NewJSONFixture(dataFile)
-	if err != nil {
-		panic(err)
-	}
-	gdt.Fixtures.Register("books_data", dataFixture)
+	gdt.Fixtures.Register("books_data", dataFixture())
 
 	// Construct a new gdt.Runnable from the directory of this file
-	_, filename, _, _ := runtime.Caller(0)
-	cwd := filepath.Dir(filename)
-
-	ts, err := gdt.From(cwd)
+	ts, err := gdt.From(currentDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/file.go
+++ b/file.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package gdt
 
 import (

--- a/fixture.go
+++ b/fixture.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package gdt
 
 import (
@@ -5,14 +9,39 @@ import (
 )
 
 var (
-	// Fixtures is the default fixture registry for gdt
-	Fixtures      = &gdtFixtureReg
-	gdtFixtureReg = fixtureRegistry{
+	// Fixtures is the fixture registry for gdt
+	Fixtures = &fixReg
+	fixReg   = fixtureRegistry{
 		entries: map[string]Fixture{},
 	}
 )
 
-// implements interfaces.FixtureRegistry
+// A Fixture allows state to be passed from setups
+type Fixture interface {
+	// Start sets up the fixture
+	Start()
+	// Stop tears down the fixture, cleaning up any owned resources
+	Stop()
+	// HasState returns true if the fixture contains some state with the given
+	// key
+	HasState(string) bool
+	// State returns the state data at the given key, or nil if no such state
+	// key is managed by the fixture
+	State(string) interface{}
+}
+
+// FixtureRegistry describes something that can register and return fixtures
+type FixtureRegistry interface {
+	// Register associates a fixture to a fixture name
+	Register(string, Fixture)
+	// Get returns a fixture with a given name or nil if no such fixture was
+	// recognized in the fixture registry
+	Get(string) Fixture
+	// List returns a slice of fixtures registered with the registry
+	List() []Fixture
+}
+
+// fixtureRegistry stores all known Fixtures
 type fixtureRegistry struct {
 	entries map[string]Fixture
 }
@@ -31,7 +60,7 @@ func (fr *fixtureRegistry) Get(name string) Fixture {
 	return fr.entries[strings.ToLower(name)]
 }
 
-// List returns an array of fixtures
+// List returns a slice of registered fixtures
 func (fr *fixtureRegistry) List() []Fixture {
 	res := make([]Fixture, len(fr.entries))
 	x := 0

--- a/fixtures/adapt.go
+++ b/fixtures/adapt.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package fixtures
 
 import "github.com/jaypipes/gdt"

--- a/fixtures/adapt.go
+++ b/fixtures/adapt.go
@@ -4,12 +4,16 @@
 
 package fixtures
 
-import "github.com/jaypipes/gdt"
+import (
+	"strings"
+
+	"github.com/jaypipes/gdt"
+)
 
 type simpleFixture struct {
 	starter func()
 	stopper func()
-	state   map[string]string
+	state   map[string]interface{}
 }
 
 // Start sets up any resources the fixture uses
@@ -30,26 +34,25 @@ func (f *simpleFixture) Stop() {
 // key
 func (f *simpleFixture) HasState(key string) bool {
 	if f.state != nil {
-		if _, ok := f.state[key]; ok {
-			return true
-		}
+		_, ok := f.state[strings.ToLower(key)]
+		return ok
 	}
 	return false
 }
 
-// GetState returns a string attribute from the fixture's state map if the
-// supplied key exists, otherwise returns empty string
+// State returns a piece of state from the fixture's state map if the supplied
+// key exists, otherwise returns nil
 func (f *simpleFixture) State(key string) interface{} {
 	if f.state != nil {
-		return f.state[key]
+		return f.state[strings.ToLower(key)]
 	}
-	return ""
+	return nil
 }
 
 type WithOption struct {
 	Starter func()
 	Stopper func()
-	State   map[string]string
+	State   map[string]interface{}
 }
 
 // WithStart allows a starter functor to be adapted into a fixture
@@ -63,7 +66,7 @@ func WithStop(stopper func()) WithOption {
 }
 
 // WithState allows a map of state key/values to be adapted into a fixture
-func WithState(state map[string]string) WithOption {
+func WithState(state map[string]interface{}) WithOption {
 	return WithOption{State: state}
 }
 

--- a/fixtures/json.go
+++ b/fixtures/json.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package fixtures
 
 import (

--- a/fixtures/json.go
+++ b/fixtures/json.go
@@ -38,14 +38,15 @@ func (f *jsonFixture) HasState(path string) bool {
 	return true
 }
 
-// GetState returns the value at supplied JSONPath expression
+// GetState returns the value at supplied JSONPath expression or nil if the
+// JSONPath expression does not result in any matched field
 func (f *jsonFixture) State(path string) interface{} {
 	if f.data == nil {
-		return ""
+		return nil
 	}
 	got, err := jsonpath.Get(path, f.data)
 	if err != nil {
-		return ""
+		return nil
 	}
 	switch got.(type) {
 	case string:
@@ -53,7 +54,7 @@ func (f *jsonFixture) State(path string) interface{} {
 	case float64:
 		return strconv.FormatFloat(got.(float64), 'f', 0, 64)
 	default:
-		return ""
+		return nil
 	}
 }
 

--- a/from.go
+++ b/from.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package gdt
 
 import (

--- a/from.go
+++ b/from.go
@@ -52,7 +52,7 @@ func fromDir(ctx *Context, dirPath string) (Runnable, error) {
 	// List YAML files in the directory and parse each into a testable unit
 	s := &suite{
 		path: dirPath,
-		// TODO(jaypipes): Allows name/description of suite
+		// TODO(jaypipes): Allow name/description of suite
 		name:        dirPath,
 		description: dirPath,
 	}

--- a/http/assertions.go
+++ b/http/assertions.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package http
 
 import (

--- a/http/errors.go
+++ b/http/errors.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package http
 
 import (

--- a/http/file.go
+++ b/http/file.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package http
 
 import (

--- a/http/fixture.go
+++ b/http/fixture.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package http
 
 import (

--- a/http/formats.go
+++ b/http/formats.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package http
 
 import (

--- a/http/parse.go
+++ b/http/parse.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package http
 
 import (

--- a/http/register.go
+++ b/http/register.go
@@ -1,7 +1,11 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package http
 
 import "github.com/jaypipes/gdt"
 
 func init() {
-	gdt.RegisterParser(&httpParser{}, "http", "")
+	gdt.Parsers.Register(&httpParser{}, "http", "")
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -2,28 +2,6 @@ package gdt
 
 import "testing"
 
-// A Fixture allows state to be passed from setups
-type Fixture interface {
-	Start()
-	Stop()
-	HasState(string) bool
-	State(string) interface{}
-}
-
-// FixtureRegistry describes something that can register and return fixtures
-type FixtureRegistry interface {
-	Register(string, Fixture)
-	Get(string) Fixture
-	List() []Fixture
-}
-
-// Parser is the driver interface for parsers of different types of tests
-type Parser interface {
-	// Parse the supplied raw contents and append any elements to the supplied
-	// ContextAppendable
-	Parse(ca ContextAppendable, contents []byte) error
-}
-
 // Runnable represents things that have a simple Run() method that accepts a
 // pointer to a testing.T. Example things that implement this interface are
 // gdt.TestCase and gdt.TestSuite

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package gdt
 
 import (
@@ -13,9 +17,7 @@ func (p *fooParser) Parse(ContextAppendable, []byte) error {
 }
 
 func TestParseBytes(t *testing.T) {
-	fakeParsers := map[string]Parser{
-		"foo": &fooParser{},
-	}
+	Parsers.Register(&fooParser{}, "foo")
 	tests := []struct {
 		name     string
 		contents []byte
@@ -53,7 +55,7 @@ name: foo test
 		tf := file{
 			name: test.name,
 		}
-		got := parseBytes(&tf, test.contents, &fakeParsers)
+		got := parseBytes(&tf, test.contents)
 		assert.Equal(t, test.exp, got)
 	}
 }

--- a/print.go
+++ b/print.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package gdt
 
 import (

--- a/suite.go
+++ b/suite.go
@@ -1,3 +1,7 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
 package gdt
 
 import (


### PR DESCRIPTION
PR includes a number of commits that clean up the gdt codebase, adding
standard Apache 2 headers, standardizing the fixtureRegistry and parserRegistry
types and simplifying the example suite_test.go file.